### PR TITLE
Emails with long subjects

### DIFF
--- a/django_yubin/models.py
+++ b/django_yubin/models.py
@@ -1,5 +1,7 @@
 import datetime
 import logging
+import email
+from email import policy
 from email import encoders as Encoders
 from email.mime.base import MIMEBase
 
@@ -15,7 +17,7 @@ from django.utils.module_loading import import_string
 from django.utils.text import Truncator
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
-import mailparser
+from mailparser import MailParser
 
 from . import mailparser_utils, tasks
 
@@ -131,7 +133,8 @@ class Message(models.Model):
         return self.to() + self.cc() + self.bcc()
 
     def get_message_parser(self):
-        return mailparser.parse_from_string(self.message_data)
+        message = email.message_from_string(self.message_data, policy=policy.default)
+        return MailParser(message)
 
     def get_email_message(self):
         """


### PR DESCRIPTION
Fixes https://github.com/open-formulieren/open-forms/issues/3448

What is happening:
- During queuing of message, django Yubin calls email_message.message() https://github.com/APSL/django-yubin/blob/master/django_yubin/__init__.py#L35 to get the message data as a string so that it can be saved to the database. When processing the headers, django core email module calls https://github.com/django/django/blob/main/django/core/mail/message.py#L74. This has the effect of adding `\n` characters to long subject lines.
- The resulting message is saved into the database (and it contains `\n` in the subject).
- When the queued task is picked up, the message is recreated from the string data before being sent https://github.com/APSL/django-yubin/blob/master/django_yubin/engine.py#L54, https://github.com/APSL/django-yubin/blob/master/django_yubin/models.py#L146. The checks for the new lines are done and they fail: https://github.com/django/django/blob/main/django/core/mail/message.py#L59